### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-run-and-push.yml
+++ b/.github/workflows/python-run-and-push.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     # Display name of the job in the GitHub Actions UI
     name: Execute main.go and Push Changes
+    permissions:
+      contents: write
     # Specify the type of runner (a fresh Ubuntu VM)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/basf-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/basf-com-documentation/security/code-scanning/1)

To fix the issue, explicitly define a `permissions` block in the workflow file. Since this workflow pushes changes to the repository, it needs `contents: write` permissions. Other permissions should be avoided unless explicitly required. The `permissions` block can be added either at the workflow level (applying to all jobs) or at the job level (specific to the `build` job). In this case, adding it to the job level is preferable to maintain clarity about permissions specific to this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
